### PR TITLE
Remove CPU PThread Early Termination

### DIFF
--- a/src/parallel_pthread.c
+++ b/src/parallel_pthread.c
@@ -43,10 +43,6 @@ void* KernelSHA256d(void* threadArg)
 
     for (index = 0; index < length; index++)
     {
-        if (nr->nonce_found)
-        {
-            break;
-        }
         //Compute SHA-256 Message Schedule
         unsigned int* le_data = (unsigned int *) ctx->data;
         for(i = 0; i < 16; i++)


### PR DESCRIPTION
Remove CPU PThread Early Termination:
1. To get fair performance measurement, SHA256 computation needs to be applied to all nonce values. So all nonce values that satisfy the requirement should be run and collected.